### PR TITLE
Spelling error in the file.

### DIFF
--- a/MM_ScienceContainers.cfg
+++ b/MM_ScienceContainers.cfg
@@ -1,4 +1,4 @@
-@PART[*]:HAS[@MODULE[ModuleCommand],!MODULE[ScienceContianer]]{
+@PART[*]:HAS[@MODULE[ModuleCommand],!MODULE[ScienceContainer]]{
 	MODULE{
 		name = ScienceContainer
 	}


### PR DESCRIPTION
Replaced "ScienceContianer" by "ScienceContainer".
