### PR TITLE
Update for KSP 1.0.5

### DIFF
--- a/src/ProbeScienceContainer.cs
+++ b/src/ProbeScienceContainer.cs
@@ -81,6 +81,13 @@ namespace ScienceContainers {
 			ScreenMessages.PostScreenMessage("<color=#ff9900ff>[" + part.partInfo.title + "]: " + data.title + " Removed</color>", 5f, ScreenMessageStyle.UPPER_LEFT);
 		}
 
+		public void ReturnData(ScienceData data) {
+			if (data == null)
+				return;
+
+			storedData.Add(data);
+		}
+
 		public void ReviewData() {
 			foreach(ScienceData data in storedData) {
 				ReviewDataItem(data);
@@ -96,7 +103,7 @@ namespace ScienceContainers {
 				false,
 				"",
 				false,
-				data.labBoost < 1 && vessel.FindPartModulesImplementing<ModuleScienceLab>().Count > 0 && ModuleScienceLab.IsLabData(data),
+				ModuleScienceLab.IsLabData(vessel, data),
 				new Callback<ScienceData>(onDiscardData),
 				new Callback<ScienceData>(onKeepData),
 				new Callback<ScienceData>(onTransmitData),
@@ -172,6 +179,7 @@ namespace ScienceContainers {
 				foreach(IScienceDataContainer c in containers) {
 					foreach(ScienceData d in c.GetData()) {
 						if(d != null) {
+							d.container = part.flightID;
 							storedData.Add(d);
 							c.DumpData(d);
 							updateMenu();
@@ -208,6 +216,7 @@ namespace ScienceContainers {
 			foreach(ModuleScienceContainer c in FlightGlobals.ActiveVessel.FindPartModulesImplementing<ModuleScienceContainer>()) {
 				foreach(ScienceData d in c.GetData()) {
 					if(d != null) {
+						d.container = part.flightID;
 						storedData.Add(d);
 						c.DumpData(d);
 						ScreenMessages.PostScreenMessage("<color=#99ff00ff>[" + part.partInfo.title + "]: <i>" + d.title + " </i> Added</color>", 5f, ScreenMessageStyle.UPPER_LEFT);


### PR DESCRIPTION
The new KSP update adds a new method to the IScienceDataContainer interface, which breaks everything that was using it before.

This update implements that method, makes use of the new part id for ScienceData (which is used to return data to the proper part when transmission fails), and makes sure the lab processing option shows up when it should in the experimental results page (this was a KSP 1.0 change).
